### PR TITLE
Add an override to Contao Templates

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -99,4 +99,5 @@ if ('FE' === TL_MODE) {
     $GLOBALS['TL_HOOKS']['executePreActions'][] = array('\WEM\SmartGear\Hooks\ExecutePreActionsHook', 'catchApiRequests');
     $GLOBALS['TL_HOOKS']['generateFrontendUrl'][] = array('\WEM\SmartGear\Hooks\GenerateFrontendUrlHook', 'generateFrontendUrl');
     $GLOBALS['TL_HOOKS']['generateBreadcrumb'][] = array('\WEM\SmartGear\Hooks\GenerateBreadcrumbHook', 'updateRootItem');
+    $GLOBALS['TL_HOOKS']['parseTemplate'][] = array('\WEM\SmartGear\Hooks\ParseTemplateHook', 'overrideDefaultTemplate');
 }

--- a/library/WEM/SmartGear/Backend/Core/Core.php
+++ b/library/WEM/SmartGear/Backend/Core/Core.php
@@ -288,6 +288,9 @@ class Core extends Block implements BlockInterface
             $objFiles->rcopy('system/modules/wem-contao-smartgear/assets/templates_app', 'app');
             $objFiles->rcopy('system/modules/wem-contao-smartgear/assets/vendor', 'files/vendor');
 
+            // Create the theme template folder
+            $objFiles->mkdir(sprintf('templates/%s', \StringUtil::generateAlias($arrConfig['websiteTitle'])));
+
             // Copy package themes into framway folder
             $objFolder = new \Folder($ftp);
             $objFiles->rcopy('system/modules/wem-contao-smartgear/assets/themes_framway', $ftp);
@@ -334,7 +337,7 @@ class Core extends Block implements BlockInterface
             $objTheme->tstamp = time();
             $objTheme->name = 'Smartgear';
             $objTheme->author = 'Web ex Machina';
-            $objTheme->templates = 'templates/smartgear';
+            $objTheme->templates = sprintf('templates/%s', \StringUtil::generateAlias($arrConfig['websiteTitle']));
             $objTheme->save();
             $this->sgConfig['sgInstallTheme'] = $objTheme->id;
             $this->logs[] = ['status' => 'tl_confirm', 'msg' => sprintf('Le thème %s a été créé et sera utilisé pour la suite de la configuration', $objTheme->name)];

--- a/library/WEM/SmartGear/Hooks/ParseTemplateHook.php
+++ b/library/WEM/SmartGear/Hooks/ParseTemplateHook.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * SMARTGEAR for Contao Open Source CMS
+ *
+ * Copyright (c) 2015-2019 Web ex Machina
+ *
+ * @category ContaoBundle
+ * @package  Web-Ex-Machina/contao-smartgear
+ * @author   Web ex Machina <contact@webexmachina.fr>
+ * @link     https://github.com/Web-Ex-Machina/contao-smartgear/
+ */
+
+namespace WEM\SmartGear\Hooks;
+
+/**
+ * Class ParseTemplateHook
+ *
+ * Handle Smartgear getPageLayout hooks
+ */
+class ParseTemplateHook
+{
+    /**
+     * Get default Smartgear template instead of default Contao
+     * if there is no override found
+     *
+     * @param Template $objTemplate [Template to parse]
+     *
+     * @return Void
+     */
+    public function overrideDefaultTemplate($objTemplate): void
+    {
+        global $objPage;
+
+        $file = $objTemplate->getName() . '.html5';
+        $rootDir = \System::getContainer()->getParameter('kernel.project_dir');
+        $sgDir = 'templates/smartgear';
+
+        // If we have set up a memory, reset the system so each template will 
+        // check in the real folder first
+        if($objPage->templateGroupMemory) {
+            $objPage->templateGroup = $objPage->templateGroupMemory;
+        }
+
+        // If the template does not exists in the objPage template group
+        // BUT it exists in the templates/smartgear folder
+        // We are updating the objPage template folder by the smartgear one
+        if (!file_exists($rootDir . '/' . $objPage->templateGroup . '/' . $file)
+            && file_exists($rootDir . '/' . $sgDir . '/' . $file)) {
+            $objPage->templateGroupMemory = $objPage->templateGroup; // Trick to reset the system for the next iteration of the hook
+            $objPage->templateGroup = $sgDir;
+        }
+    }
+}


### PR DESCRIPTION
Allow Smartgear to be a default path of templates **before** checking default files of Contao.