### PR TITLE
Issue #193 : fix redactors groupe name and configuration

### DIFF
--- a/src/Backend/Component/Blog/ConfigurationStep/General.php
+++ b/src/Backend/Component/Blog/ConfigurationStep/General.php
@@ -241,12 +241,12 @@ class General extends ConfigurationStep
         $presetConfig = $blogConfig->getCurrentPreset();
 
         $objUserGroupAdministrators = UserGroupModel::findOneById($config->getSgUserGroupAdministrators());
-        $objUserGroupWebmasters = UserGroupModel::findOneById($config->getSgUserGroupWebmasters());
+        $objUserGroupRedactors = UserGroupModel::findOneById($config->getSgUserGroupRedactors());
 
         $newsArchive = NewsArchiveModel::findById($blogConfig->getSgNewsArchive()) ?? new NewsArchiveModel();
         $newsArchive->title = $presetConfig->getSgNewsArchiveTitle();
         $newsArchive->jumpTo = $page->id;
-        $newsArchive->groups = serialize([$objUserGroupAdministrators->id, $objUserGroupWebmasters->id]);
+        $newsArchive->groups = serialize([$objUserGroupAdministrators->id, $objUserGroupRedactors->id]);
         $newsArchive->tstamp = time();
         $newsArchive->save();
 
@@ -367,7 +367,7 @@ class General extends ConfigurationStep
         /** @var BlogConfig */
         $blogConfig = $config->getSgBlog();
 
-        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $expertMode, $blogConfig);
+        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $expertMode, $blogConfig);
         $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), true, $blogConfig);
     }
 
@@ -380,12 +380,12 @@ class General extends ConfigurationStep
 
         $userGroupManipulator = UserGroupModelUtil::create($objUserGroup);
         $userGroupManipulator
-            // ->addAllowedModules(['news'])
+            ->addAllowedModules(['news'])
             ->addAllowedNewsArchive([$blogConfig->getSgNewsArchive()])
             ->addAllowedFilemounts([$objFolder->uuid])
             ->addAllowedFieldsByTables(['tl_news'])
             ->addAllowedPagemounts($blogConfig->getContaoPagesIds())
-            ->addAllowedModules(Module::getTypesByIds($blogConfig->getContaoModulesIds()))
+            // ->addAllowedModules(Module::getTypesByIds($blogConfig->getContaoModulesIds()))
         ;
         if ($expertMode) {
             $userGroupManipulator

--- a/src/Backend/Component/Blog/Resetter.php
+++ b/src/Backend/Component/Blog/Resetter.php
@@ -174,7 +174,7 @@ class Resetter extends BackendResetter
         /** @var BlogConfig */
         $blogConfig = $config->getSgBlog();
 
-        $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $blogConfig);
+        $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $blogConfig);
         $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), $blogConfig);
     }
 

--- a/src/Backend/Component/Core/ConfigurationStep/Website.php
+++ b/src/Backend/Component/Core/ConfigurationStep/Website.php
@@ -544,7 +544,7 @@ class Website extends ConfigurationStep
         // $objUser->password = \Contao\Encryption::hash('webmaster');
         $objUser->password = password_hash('webmaster', \PASSWORD_DEFAULT);
         $objUser->pwChange = 1;
-        $objUser->groups = serialize([0 => $groups['administrators']->id]);
+        $objUser->groups = serialize([0 => $groups['redactors']->id]);
         $objUser->inherit = 'group';
         $objUser->save();
 

--- a/src/Backend/Component/Core/ConfigurationStep/Website.php
+++ b/src/Backend/Component/Core/ConfigurationStep/Website.php
@@ -321,6 +321,18 @@ class Website extends ConfigurationStep
         $objSocialLinkModule->save();
         $modules[$objSocialLinkModule->type] = $objSocialLinkModule;
 
+        // Social Link Categories
+        $objSocialLinkCategoriesModule = \array_key_exists('wem_sg_social_link_config_categories', $registeredModules)
+                            ? ModuleModel::findOneById($registeredModules['wem_sg_social_link_config_categories']) ?? new ModuleModel()
+                            : new ModuleModel()
+                            ;
+        $objSocialLinkCategoriesModule->pid = $themeId;
+        $objSocialLinkCategoriesModule->tstamp = time();
+        $objSocialLinkCategoriesModule->type = 'wem_sg_social_link_config_categories';
+        $objSocialLinkCategoriesModule->name = $GLOBALS['TL_LANG']['WEMSG']['INSTALL']['WEBSITE']['ModuleSocialLinkConfigCategoriesName'];
+        $objSocialLinkCategoriesModule->save();
+        $modules[$objSocialLinkCategoriesModule->type] = $objSocialLinkCategoriesModule;
+
         // Personal Data Manager
         $objPDMModule = \array_key_exists('wem_personaldatamanager', $registeredModules)
                             ? ModuleModel::findOneById($registeredModules['wem_personaldatamanager']) ?? new ModuleModel()
@@ -459,12 +471,12 @@ class Website extends ConfigurationStep
         $userGroups['administrators'] = $objUserGroup;
 
         if (null !== $config->getSgUserGroupAdministrators()) {
-            $objUserGroup = UserGroupModel::findOneById($config->getSgUserGroupWebmasters()) ?? new UserGroupModel();
+            $objUserGroup = UserGroupModel::findOneById($config->getSgUserGroupRedactors()) ?? new UserGroupModel();
         } else {
             $objUserGroup = new UserGroupModel();
         }
         $objUserGroup->tstamp = time();
-        $objUserGroup->name = $GLOBALS['TL_LANG']['WEMSG']['INSTALL']['WEBSITE']['UsergroupWebmastersName'];
+        $objUserGroup->name = $GLOBALS['TL_LANG']['WEMSG']['INSTALL']['WEBSITE']['UsergroupRedactorsName'];
         $objUserGroup->modules = serialize(['article', 'files']);
         $objUserGroup->alexf = Util::addPermissions($this->getCorePermissions());
         $objUserGroup->imageSizes = serialize(['proportional']);
@@ -503,7 +515,7 @@ class Website extends ConfigurationStep
             'rsce_blockCard',
         ]);
         $objUserGroup->save();
-        $userGroups['webmasters'] = $objUserGroup;
+        $userGroups['redactors'] = $objUserGroup;
 
         return $userGroups;
     }
@@ -944,7 +956,7 @@ class Website extends ConfigurationStep
         $config = $this->configurationManager->load();
 
         $config->setSgUserWebmaster((int) $users['webmaster']->id);
-        $config->setSgUserGroupWebmasters((int) $groups['webmasters']->id);
+        $config->setSgUserGroupRedactors((int) $groups['redactors']->id);
         $config->setSgUserGroupAdministrators((int) $groups['administrators']->id);
 
         $this->configurationManager->save($config);
@@ -1200,7 +1212,7 @@ class Website extends ConfigurationStep
         /** @var CoreConfig */
         $config = $this->configurationManager->load();
 
-        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $config);
+        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $config);
         $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), $config);
     }
 

--- a/src/Backend/Component/Events/ConfigurationStep/General.php
+++ b/src/Backend/Component/Events/ConfigurationStep/General.php
@@ -32,7 +32,6 @@ use WEM\SmartgearBundle\Classes\UserGroupModelUtil;
 use WEM\SmartgearBundle\Classes\Util;
 use WEM\SmartgearBundle\Config\Component\Core\Core as CoreConfig;
 use WEM\SmartgearBundle\Config\Component\Events\Events as EventsConfig;
-use WEM\SmartgearBundle\Model\Module;
 use WEM\SmartgearBundle\Security\SmartgearPermissions;
 
 class General extends ConfigurationStep
@@ -189,12 +188,12 @@ class General extends ConfigurationStep
         $eventsConfig = $config->getSgEvents();
 
         $objUserGroupAdministrators = UserGroupModel::findOneById($config->getSgUserGroupAdministrators());
-        $objUserGroupWebmasters = UserGroupModel::findOneById($config->getSgUserGroupWebmasters());
+        $objUserGroupRedactors = UserGroupModel::findOneById($config->getSgUserGroupRedactors());
 
         $calendar = CalendarModel::findById($eventsConfig->getSgCalendar()) ?? new CalendarModel();
         $calendar->title = $eventsConfig->getSgCalendarTitle();
         $calendar->jumpTo = $page->id;
-        $calendar->groups = serialize([$objUserGroupAdministrators->id, $objUserGroupWebmasters->id]);
+        $calendar->groups = serialize([$objUserGroupAdministrators->id, $objUserGroupRedactors->id]);
         $calendar->tstamp = time();
         $calendar->save();
 
@@ -333,7 +332,7 @@ class General extends ConfigurationStep
         /** @var EventsConfig */
         $eventsConfig = $config->getSgEvents();
 
-        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $expertMode, $eventsConfig);
+        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $expertMode, $eventsConfig);
         $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), true, $eventsConfig);
     }
 
@@ -351,7 +350,6 @@ class General extends ConfigurationStep
             ->addAllowedFilemounts([$objFolder->uuid])
             ->addAllowedFieldsByTables(['tl_calendar_events'])
             ->addAllowedPagemounts($eventsConfig->getContaoPagesIds())
-            ->addAllowedModules(Module::getTypesByIds($eventsConfig->getContaoModulesIds()))
         ;
         if ($expertMode) {
             $userGroupManipulator

--- a/src/Backend/Component/Events/Resetter.php
+++ b/src/Backend/Component/Events/Resetter.php
@@ -172,7 +172,7 @@ class Resetter extends BackendResetter
         /** @var EventsConfig */
         $eventsConfig = $config->getSgEvents();
 
-        $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $eventsConfig);
+        $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $eventsConfig);
         $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), $eventsConfig);
     }
 

--- a/src/Backend/Component/Faq/ConfigurationStep/General.php
+++ b/src/Backend/Component/Faq/ConfigurationStep/General.php
@@ -163,12 +163,12 @@ class General extends ConfigurationStep
         $faqConfig = $config->getSgFaq();
 
         $objUserGroupAdministrators = UserGroupModel::findOneById($config->getSgUserGroupAdministrators());
-        $objUserGroupWebmasters = UserGroupModel::findOneById($config->getSgUserGroupWebmasters());
+        $objUserGroupRedactors = UserGroupModel::findOneById($config->getSgUserGroupRedactors());
 
         $faqCategory = FaqCategoryModel::findById($faqConfig->getSgFaqCategory()) ?? new FaqCategoryModel();
         $faqCategory->title = $faqConfig->getSgFaqTitle();
         $faqCategory->jumpTo = $page->id;
-        $faqCategory->groups = serialize([$objUserGroupAdministrators->id, $objUserGroupWebmasters->id]);
+        $faqCategory->groups = serialize([$objUserGroupAdministrators->id, $objUserGroupRedactors->id]);
         $faqCategory->tstamp = time();
         $faqCategory->save();
 
@@ -249,7 +249,7 @@ class General extends ConfigurationStep
         /** @var FaqConfig */
         $faqConfig = $config->getSgFaq();
 
-        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $faqConfig);
+        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $faqConfig);
         $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), $faqConfig);
     }
 
@@ -267,7 +267,7 @@ class General extends ConfigurationStep
             ->addAllowedFilemounts([$objFolder->uuid])
             ->addAllowedFieldsByTables(['tl_faq'])
             ->addAllowedPagemounts($faqConfig->getContaoPagesIds())
-            ->addAllowedModules(Module::getTypesByIds($faqConfig->getContaoModulesIds()))
+            // ->addAllowedModules(Module::getTypesByIds($faqConfig->getContaoModulesIds()))
         ;
 
         $objUserGroup = $userGroupManipulator->getUserGroup();

--- a/src/Backend/Component/Faq/Resetter.php
+++ b/src/Backend/Component/Faq/Resetter.php
@@ -172,7 +172,7 @@ class Resetter extends BackendResetter
         /** @var FaqConfig */
         $faqConfig = $config->getSgFaq();
 
-        $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $faqConfig);
+        $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $faqConfig);
         $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), $faqConfig);
     }
 

--- a/src/Backend/Component/FormContact/ConfigurationStep/General.php
+++ b/src/Backend/Component/FormContact/ConfigurationStep/General.php
@@ -507,7 +507,7 @@ class General extends ConfigurationStep
         $formContactConfig = $config->getSgFormContact();
 
         // retrieve the webmaster's group and update the permissions
-        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $formContactConfig);
+        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $formContactConfig);
         $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), $formContactConfig);
     }
 
@@ -520,7 +520,7 @@ class General extends ConfigurationStep
             ->addAllowedFormFields(['text', 'textarea', 'captcha', 'submit'])
             ->addAllowedFieldsByTables(['tl_form', 'tl_form_field'])
             ->addAllowedPagemounts($formContactConfig->getContaoPagesIds())
-            ->addAllowedModules(Module::getTypesByIds($formContactConfig->getContaoModulesIds()))
+            // ->addAllowedModules(Module::getTypesByIds($formContactConfig->getContaoModulesIds()))
         ;
         $objUserGroup = $userGroupManipulator->getUserGroup();
         $objUserGroup->formp = serialize(['create', 'delete']);

--- a/src/Backend/Component/FormContact/Resetter.php
+++ b/src/Backend/Component/FormContact/Resetter.php
@@ -236,7 +236,7 @@ class Resetter extends BackendResetter
         /** @var FormContactConfig */
         $formContactConfig = $config->getSgFormContact();
 
-        $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $formContactConfig);
+        $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $formContactConfig);
         $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), $formContactConfig);
     }
 

--- a/src/Backend/Module/Extranet/ConfigurationStep/General.php
+++ b/src/Backend/Module/Extranet/ConfigurationStep/General.php
@@ -1843,7 +1843,7 @@ class General extends ConfigurationStep
             }
         }
 
-        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $extranetConfig, $modulesTypes);
+        $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $extranetConfig, $modulesTypes);
         $this->updateUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), $extranetConfig, $modulesTypes);
     }
 

--- a/src/Backend/Module/Extranet/Resetter.php
+++ b/src/Backend/Module/Extranet/Resetter.php
@@ -564,7 +564,7 @@ class Resetter extends BackendResetter
         /** @var ExtranetConfig */
         $extranetConfig = $config->getSgExtranet();
 
-        $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupWebmasters()), $extranetConfig);
+        $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupRedactors()), $extranetConfig);
         $this->resetUserGroup(UserGroupModel::findOneById($config->getSgUserGroupAdministrators()), $extranetConfig);
     }
 

--- a/src/Classes/Util.php
+++ b/src/Classes/Util.php
@@ -601,7 +601,7 @@ class Util
                 $conf = self::loadSmartgearConfig();
 
                 // if ($conf['sgInstallUserGroup']) {
-                $objUserGroup = UserGroupModel::findOneById($conf->getSgUserGroupWebmasters());
+                $objUserGroup = UserGroupModel::findOneById($conf->getSgUserGroupRedactors());
             // }
             } else {
                 $objUserGroup = UserGroupModel::findByPk($intGroup);
@@ -648,7 +648,7 @@ class Util
                 $conf = self::loadSmartgearConfig();
 
                 if ($conf['sgInstallUserGroup']) {
-                    $objUserGroup = UserGroupModel::findByPk($conf->getSgUserGroupWebmasters());
+                    $objUserGroup = UserGroupModel::findByPk($conf->getSgUserGroupRedactors());
                 }
             } else {
                 $objUserGroup = UserGroupModel::findByPk($intGroup);

--- a/src/Config/Component/Core/Core.php
+++ b/src/Config/Component/Core/Core.php
@@ -145,7 +145,7 @@ class Core implements ConfigModuleInterface
     /** @var int */
     protected $sgUserWebmaster;
     /** @var int */
-    protected $sgUserGroupWebmasters;
+    protected $sgUserGroupRedactors;
     /** @var int */
     protected $sgUserGroupAdministrators;
     /** @var int */
@@ -195,7 +195,7 @@ class Core implements ConfigModuleInterface
             ->setSgContentPrivacyPolitics(null)
             ->setSgContentSitemap(null)
             ->setSgUserWebmaster(null)
-            ->setSgUserGroupWebmasters(null)
+            ->setSgUserGroupRedactors(null)
             ->setSgUserGroupAdministrators(null)
             ->setSgModules([])
             ->setSgSelectedModules([])
@@ -259,7 +259,7 @@ class Core implements ConfigModuleInterface
             ->setSgContentPrivacyPolitics($json->contao->contents->privacyPolitics ?? null)
             ->setSgContentSitemap($json->contao->contents->sitemap ?? null)
             ->setSgUserWebmaster($json->contao->users->webmaster ?? null)
-            ->setSgUserGroupWebmasters($json->contao->userGroups->webmasters ?? null)
+            ->setSgUserGroupRedactors($json->contao->userGroups->redactors ?? null)
             ->setSgUserGroupAdministrators($json->contao->userGroups->administrators ?? null)
             ->setSgModules($json->contao->modules ?? [])
             ->setSgSelectedModules($json->selectedModules ?? [])
@@ -359,7 +359,7 @@ class Core implements ConfigModuleInterface
         $json->contao->users->webmaster = $this->getSgUserWebmaster();
 
         $json->contao->userGroups = new \stdClass();
-        $json->contao->userGroups->webmasters = $this->getSgUserGroupWebmasters();
+        $json->contao->userGroups->redactors = $this->getSgUserGroupRedactors();
         $json->contao->userGroups->administrators = $this->getSgUserGroupAdministrators();
 
         $json->contao->layouts = new \stdClass();
@@ -660,7 +660,7 @@ class Core implements ConfigModuleInterface
 
         return [
             $this->getSgUserGroupAdministrators(),
-            $this->getSgUserGroupWebmasters(),
+            $this->getSgUserGroupRedactors(),
         ];
     }
 
@@ -751,7 +751,7 @@ class Core implements ConfigModuleInterface
     public function resetContaoUserGroupsIds(): void
     {
         $this->setSgUserGroupAdministrators(null);
-        $this->setSgUserGroupWebmasters(null);
+        $this->setSgUserGroupRedactors(null);
     }
 
     public function resetContaoMembersIds(): void
@@ -1165,14 +1165,14 @@ class Core implements ConfigModuleInterface
         return $this;
     }
 
-    public function getSgUserGroupWebmasters(): ?int
+    public function getSgUserGroupRedactors(): ?int
     {
-        return $this->sgUserGroupWebmasters;
+        return $this->sgUserGroupRedactors;
     }
 
-    public function setSgUserGroupWebmasters(?int $sgUserGroupWebmasters): self
+    public function setSgUserGroupRedactors(?int $sgUserGroupRedactors): self
     {
-        $this->sgUserGroupWebmasters = $sgUserGroupWebmasters;
+        $this->sgUserGroupRedactors = $sgUserGroupRedactors;
 
         return $this;
     }

--- a/src/Resources/contao/languages/fr/default.xlf
+++ b/src/Resources/contao/languages/fr/default.xlf
@@ -497,6 +497,10 @@
 			<source>Social network links</source>
 			<target>Liens réseaux sociaux</target>
 		</trans-unit>
+		<trans-unit id="WEMSG.INSTALL.WEBSITE.ModuleSocialLinkConfigCategoriesName">
+			<source>Social network categories</source>
+			<target>Catégories réseaux sociaux</target>
+		</trans-unit>
 		<trans-unit id="WEMSG.INSTALL.WEBSITE.ModuleFooterNavName">
 			<source>Nav - footer</source>
 			<target>Nav - footer</target>
@@ -517,9 +521,9 @@
 			<source>Administrators</source>
 			<target>Administrateurs</target>
 		</trans-unit>
-		<trans-unit id="WEMSG.INSTALL.WEBSITE.UsergroupWebmastersName">
-			<source>Webmasters</source>
-			<target>Webmasters</target>
+		<trans-unit id="WEMSG.INSTALL.WEBSITE.UsergroupRedactorsName">
+			<source>Redactors</source>
+			<target>Rédacteurs</target>
 		</trans-unit>
 		<trans-unit id="WEMSG.INSTALL.WEBSITE.UserWebmasterName">
 			<source>Webmaster</source>


### PR DESCRIPTION
- After deploying this update, change the `contao->userGroups->webmasters` key to `contao->userGroups->redactors` in the configuration file.
- Rename `Webmaster` group to `Rédacteurs`
- Put `Webmaster` user into the `Rédacteurs` group instead of `Administrateurs`