### PR TITLE
Feat : custom language file

### DIFF
--- a/src/Classes/CustomLanguageFileLoader.php
+++ b/src/Classes/CustomLanguageFileLoader.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SMARTGEAR for Contao Open Source CMS
+ * Copyright (c) 2015-2022 Web ex Machina
+ *
+ * @category ContaoBundle
+ * @package  Web-Ex-Machina/contao-smartgear
+ * @author   Web ex Machina <contact@webexmachina.fr>
+ * @link     https://github.com/Web-Ex-Machina/contao-smartgear/
+ */
+
+namespace WEM\SmartgearBundle\Classes;
+
+use Contao\System;
+
+class CustomLanguageFileLoader
+{
+    /**
+     * Load custom language file.
+     */
+    public function loadCustomLanguageFile(?string $currentLanguage = null): void
+    {
+        // check if assets/smartgear/languages/{lang}/custom.json exists
+        // if so, include it
+        if (!$currentLanguage) {
+            $container = System::getContainer();
+            $currentLanguage = $container->get('request_stack')->getCurrentRequest()->getLocale();
+        }
+
+        $filePath = System::getContainer()->getParameter('kernel.project_dir').'/assets/smartgear/languages/'.$currentLanguage.'/custom.json';
+        if (file_exists($filePath)) {
+            $content = file_get_contents($filePath);
+            if (!$content) {
+                return;
+            }
+            $json = json_decode($content, true);
+            if (!$json) {
+                return;
+            }
+            $this->JSONFileToLangArray($json);
+        }
+    }
+
+    protected function JSONFileToLangArray(array $json): void
+    {
+        foreach ($json as $key => $value) {
+            // check if key is 4 chunks long max
+            $keys = explode('.', $key);
+            switch (\count($keys)) {
+                case 1:
+                    $GLOBALS['TL_LANG'][$keys[0]] = $value;
+                break;
+                case 2:
+                    $GLOBALS['TL_LANG'][$keys[0]][$keys[1]] = $value;
+                break;
+                case 3:
+                    $GLOBALS['TL_LANG'][$keys[0]][$keys[1]][$keys[2]] = $value;
+                break;
+                case 4:
+                    $GLOBALS['TL_LANG'][$keys[0]][$keys[1]][$keys[2]][$keys[3]] = $value;
+                break;
+                default:
+                break;
+            }
+        }
+    }
+}

--- a/src/Classes/CustomLanguageFileLoader.php
+++ b/src/Classes/CustomLanguageFileLoader.php
@@ -31,17 +31,21 @@ class CustomLanguageFileLoader
         }
 
         $filePath = System::getContainer()->getParameter('kernel.project_dir').'/assets/smartgear/languages/'.$currentLanguage.'/custom.json';
-        if (file_exists($filePath)) {
-            $content = file_get_contents($filePath);
-            if (!$content) {
-                return;
-            }
-            $json = json_decode($content, true);
-            if (!$json) {
-                return;
-            }
-            $this->JSONFileToLangArray($json);
+        if (!file_exists($filePath)) {
+            return;
         }
+
+        $content = file_get_contents($filePath);
+        if (!$content) {
+            return;
+        }
+
+        $json = json_decode($content, true);
+        if (!$json) {
+            return;
+        }
+        
+        $this->JSONFileToLangArray($json);
     }
 
     protected function JSONFileToLangArray(array $json): void

--- a/src/EventListener/LoadLanguageFileListener.php
+++ b/src/EventListener/LoadLanguageFileListener.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SMARTGEAR for Contao Open Source CMS
+ * Copyright (c) 2015-2022 Web ex Machina
+ *
+ * @category ContaoBundle
+ * @package  Web-Ex-Machina/contao-smartgear
+ * @author   Web ex Machina <contact@webexmachina.fr>
+ * @link     https://github.com/Web-Ex-Machina/contao-smartgear/
+ */
+
+namespace WEM\SmartgearBundle\EventListener;
+
+use WEM\SmartgearBundle\Classes\CustomLanguageFileLoader;
+
+class LoadLanguageFileListener
+{
+    /** @var CustomLanguageFileLoader */
+    protected $customLanguageFileLoader;
+
+    public function __construct(
+        CustomLanguageFileLoader $customLanguageFileLoader
+    ) {
+        $this->customLanguageFileLoader = $customLanguageFileLoader;
+    }
+
+    public function __invoke(string $name, string $currentLanguage, string $cacheKey): void
+    {
+        $this->customLanguageFileLoader->loadCustomLanguageFile($currentLanguage);
+    }
+}

--- a/src/Resources/config/listeners.yml
+++ b/src/Resources/config/listeners.yml
@@ -124,6 +124,7 @@ services:
         arguments:
             $configurationManager: '@smartgear.config.manager.core'
             $scopeMatcher: '@smartgear.classes.scope_matcher'
+            $customLanguageFileLoader : '@smartgear.classes.custom_language_file_loader'
         public: true
 
     smartgear.listener.get_content_element:
@@ -144,6 +145,12 @@ services:
             $configurationManager: '@smartgear.config.manager.core'
         tags:
             - { name: kernel.event_listener, event: contao.backend_menu_build }
+        public: true
+
+    smartgear.listener.load_language_file:
+        class: WEM\SmartgearBundle\EventListener\LoadLanguageFileListener
+        arguments:
+            $customLanguageFileLoader : '@smartgear.classes.custom_language_file_loader'
         public: true
 
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -220,6 +220,11 @@ services:
             $scopeMatcher : '@contao.routing.scope_matcher'
         public: true
 
+    smartgear.classes.custom_language_file_loader:
+        class: WEM\SmartgearBundle\Classes\CustomLanguageFileLoader
+        public: true
+        
+
     smartgear.config.manager.framway:
         class: WEM\SmartgearBundle\Config\Manager\Framway
         arguments:

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -200,6 +200,10 @@ if ('FE' === TL_MODE) {
 }
 
 /*
+ * Add globals Hooks
+ */
+$GLOBALS['TL_HOOKS']['loadLanguageFile'][] = ['smartgear.listener.load_language_file', '__invoke'];
+/*
  * Add custom rights
  */
 $GLOBALS['TL_PERMISSIONS'][] = 'smartgear_permissions';

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -174,6 +174,7 @@ if ('BE' === TL_MODE) {
     $GLOBALS['TL_HOOKS']['loadDataContainer'][] = ['smartgear.listener.load_data_container', '__invoke'];
     $GLOBALS['TL_HOOKS']['initializeSystem'][] = ['smartgear.listener.initialize_system', '__invoke'];
     $GLOBALS['TL_HOOKS']['replaceInsertTags'][] = ['smartgear.listener.replace_insert_tags', 'onReplaceInsertTags'];
+    $GLOBALS['TL_HOOKS']['generatePage'][] = ['smartgear.listener.generate_page', '__invoke'];
 }
 
 /*


### PR DESCRIPTION
Back-end : 
- It doesn't seem there's language cache, so the `loadLanguageFile` alone is enough

Front-end : 
- Language cache files are used, so using `generatePage` listener to make sure we load our custom file at least once.